### PR TITLE
Pin versions of 3rd-party actions and GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,16 @@ on: [push]
 
 jobs:
   buid-and-test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v4
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3
+        uses: actions/setup-python@v3
         with:
           python-version: '3.10'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3
         with:
           python-version: '3.10'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,17 @@ name: Build and Test
 
 on:
   pull_request:
+    types: [opened, synchronize]
     branches:
       - main
+
+  merge_group:
+    types:
+      - checks_requested
+
   push:
+  # Allow manual invocation.
+  workflow_dispatch:
 
 jobs:
   buid-and-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,16 @@ on:
 
 jobs:
   buid-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3
         with:
           python-version: '3.10'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ on: [push]
 
 jobs:
   buid-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,11 @@
 
 name: Build and Test
 
-on: [push]
+on:
+  pull_request:
+    branches:
+      - main
+  push:
 
 jobs:
   buid-and-test:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   create_version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -33,11 +33,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             arch: x86_64
-          - os: windows-latest
+          - os: windows-2022
             arch: auto
-          - os: macos-latest
+          - os: macos-14
             arch: auto
           - os: macos-13
             arch: auto
@@ -74,7 +74,7 @@ jobs:
   release-wheels:
     name: Publish all wheels
     needs: [build_wheels]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Download build artifacts

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,8 +12,8 @@ jobs:
   create_version:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: '3.10'
       - name: Create version
@@ -43,9 +43,9 @@ jobs:
             arch: auto
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
       with:
         python-version: '3.10'
     - name: Install dependencies
@@ -66,7 +66,7 @@ jobs:
       run: |
         python -m cibuildwheel --output-dir wheelhouse
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
       with:
         name: python-wheels-${{ matrix.os }}
         path: ./wheelhouse/*.whl
@@ -78,7 +78,7 @@ jobs:
 
     steps:
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
       with:
         pattern: python-wheels-*
         merge-multiple: true

--- a/.github/workflows/stable-release-workflow.yml
+++ b/.github/workflows/stable-release-workflow.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   create_version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -32,11 +32,11 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             arch: x86_64
-          - os: windows-latest
+          - os: windows-2022
             arch: auto
-          - os: macos-latest
+          - os: macos-14
             arch: auto
           - os: macos-13
             arch: auto
@@ -73,7 +73,7 @@ jobs:
   release-wheels:
     name: Publish all wheels
     needs: [build_wheels]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Download build artifacts

--- a/.github/workflows/stable-release-workflow.yml
+++ b/.github/workflows/stable-release-workflow.yml
@@ -11,8 +11,8 @@ jobs:
   create_version:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: '3.10'
       - name: Create version
@@ -42,9 +42,9 @@ jobs:
             arch: auto
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
       with:
         python-version: '3.10'
     - name: Install dependencies
@@ -65,7 +65,7 @@ jobs:
       run: |
         python -m cibuildwheel --output-dir wheelhouse
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
       with:
         name: python-wheels-${{ matrix.os }}
         path: ./wheelhouse/*.whl
@@ -77,7 +77,7 @@ jobs:
 
     steps:
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
       with:
         pattern: python-wheels-*
         merge-multiple: true


### PR DESCRIPTION
Google's terms for allowing the use of GitHub Actions on Google-owned repositories requires that third-party actions be referenced using a specific commit, not a tagged release or a branch name. They also recommend that GitHub-hosted runners be referenced by fixed versions and not "-latest". (Internal doc link: go/github-actions#actions)

The SHAs for GitHub Actions in this commit were obtained using [frizbee](https://github.com/stacklok/frizbee). The runner versions equivalent to the "-latest" runners are based on the table at https://github.com/actions/runner-images