### PR TITLE
Allow greater protobuf versions to support updates in dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 attrs
 cython>=3.0.0
 numpy>=1.23.0
-protobuf~=5.26
+protobuf>=4.25
 pyparsing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 attrs
 cython>=3.0.0
 numpy>=1.23.0
-protobuf~=4.25
+protobuf~=5.26
 pyparsing


### PR DESCRIPTION
This unblocks downstream updates to modern grpc and opentelemetry libraries.