### PR TITLE
Include license metadata in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setuptools.setup(
     python_requires=">=3.10.0",
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type='text/markdown',
+    license="Apache 2",
     url='https://github.com/quantumlib/TypedUnits',
     author='The TUnits Authors',
 )


### PR DESCRIPTION
This will ensure that the license metadata is correctly populated in packages uploaded to pypi.