### PR TITLE
Fix truediv type-checking for ValueType2

### DIFF
--- a/tunits/core/__init__.pyi
+++ b/tunits/core/__init__.pyi
@@ -129,7 +129,7 @@ class UnitArray:
 
 NumericalT = TypeVar('NumericalT', default=float, bound=float | int)
 ValueType = TypeVar('ValueType', bound='Value')
-ValueType2 = TypeVar('ValueType2', default='Value', bound='Value')
+ValueType2 = TypeVar('ValueType2', default='Value', bound='Value', covariant=True)
 ArrayType = TypeVar('ArrayType', bound='ValueArray')
 
 @overload


### PR DESCRIPTION
- ValueType2  (the generic parameter of ValueArray ) was defined as invariant.
- This prevents FrequencyArray (which is ValueArray[Frequency]) from being compatible with ValueArray[Value].
- As a result,  mypy could not match the  __truediv__  operator on ValueArray  and fell back to Value.__rtruediv__ , which also failed.

Fixes internal bug b/507121233